### PR TITLE
Use a sentinel to terminate TokenStream

### DIFF
--- a/kcccxx/src/lexer.cpp
+++ b/kcccxx/src/lexer.cpp
@@ -179,5 +179,6 @@ LexicalAnalysis(std::string const &filename) {
       tokens.emplace_back(TokenType::Symbol, tok);
     }
   }
+  tokens.emplace_back(TokenType::Eof, "");
   return tokens;
 }

--- a/kcccxx/src/parser.cpp
+++ b/kcccxx/src/parser.cpp
@@ -14,7 +14,7 @@
 TranslationUnitAst *
 Parser::parse_top_level_decl() {
   std::vector<Ast *> funcs;
-  while (tokens.seek()->representation() == "DefFn") {
+  while (tokens.seek()->type() != TokenType::Eof) {
     auto const fn = parse_deffn_decl();
     funcs.push_back(fn);
   }


### PR DESCRIPTION
cf. https://github.com/1995hnagamin/kceage/runs/973604083#step:8:5

Put an EOF token at the end of the TokenStream in order to avoid out-of-bound vector access.